### PR TITLE
Refactoring gestures.PhoneGesture

### DIFF
--- a/droidar/src/gestures/PhoneGesture.java
+++ b/droidar/src/gestures/PhoneGesture.java
@@ -1,25 +1,14 @@
 package gestures;
 
 /**
- * A list of possible gesture types. The gesture is explicitly called
- * **Phone**Gesture in order to avoid confusion with e.g. touch gestures that
- * can be performed on the screen. PhoneGestures involve moving the whole phone
- * (i.e. physical movement through space).
+ * To identify gestures in a structured way, we're making use of the
+ * "Extensible Enum Pattern". When creating your own gestures, create an enum
+ * that implements this interface and you will be able to pass instances of your
+ * enum in the required locations (e.g. PhoneGestureDetector.getType()).
  * 
- * @author marmat (Martin Matysiak)
+ * @see https://blogs.oracle.com/darcy/entry/enums_and_mixins
+ * @author kaktus621@gmail.com (Martin Matysiak)
  */
-public enum PhoneGesture {
-	/* No gesture detected with confidence */
-	NONE,
-	/* A simple slashing gesture */
-	SLASH,
-	/* User holds the phone in a stable position, as if looking at it */
-	LOOKING,
-	/* A "punching" gesture that goes vertically upwards */
-	UPPERCUT,
-	/*
-	 * A "360° turn" of the player (i.e., the player's nose faces all
-	 * georgraphic directions once)
-	 */
-	FULL_TURN
+public interface PhoneGesture {
+
 }

--- a/droidar/src/gestures/PhoneGestureSensor.java
+++ b/droidar/src/gestures/PhoneGestureSensor.java
@@ -72,7 +72,7 @@ public class PhoneGestureSensor implements SensorEventListener {
 		 * @return The builder instance for method chaining.
 		 */
 		public Builder withMinimumConfidence(float confidence) {
-			sensor.addDetector(new DummyDetector(PhoneGesture.NONE, confidence));
+			sensor.addDetector(new DummyDetector(StandardPhoneGesture.NONE, confidence));
 			return this;
 		}
 
@@ -183,7 +183,7 @@ public class PhoneGestureSensor implements SensorEventListener {
 	/**
 	 * The last propagated gesture.
 	 */
-	private PhoneGesture lastGesture = PhoneGesture.NONE;
+	private PhoneGesture lastGesture = StandardPhoneGesture.NONE;
 
 	/**
 	 * The gravity vector indicating the measured values of gravity along the
@@ -319,7 +319,7 @@ public class PhoneGestureSensor implements SensorEventListener {
 	private void propagateEvent(PhoneGesture phoneGesture) {
 		long currentTime = System.currentTimeMillis();
 
-		if ((lastGesture != PhoneGesture.NONE && currentTime - lastEvent < gestureTimeout)
+		if ((lastGesture != StandardPhoneGesture.NONE && currentTime - lastEvent < gestureTimeout)
 				|| lastGesture == phoneGesture) {
 			return;
 		}
@@ -361,7 +361,7 @@ public class PhoneGestureSensor implements SensorEventListener {
 		}
 
 		propagateEvent(mostProbableDetector != null ? mostProbableDetector
-				.getType() : PhoneGesture.NONE);
+				.getType() : StandardPhoneGesture.NONE);
 	}
 
 	/**

--- a/droidar/src/gestures/StandardPhoneGesture.java
+++ b/droidar/src/gestures/StandardPhoneGesture.java
@@ -1,0 +1,17 @@
+package gestures;
+
+public enum StandardPhoneGesture implements PhoneGesture {
+    /* No gesture detected with confidence */
+    NONE,
+    /* A simple slashing gesture */
+    SLASH,
+    /* User holds the phone in a stable position, as if looking at it */
+    LOOKING,
+    /* A "punching" gesture that goes vertically upwards */
+    UPPERCUT,
+    /*
+     * A "360 degree turn" of the player (i.e., the player's nose faces all
+     * georgraphic directions once)
+     */
+    FULL_TURN
+}

--- a/droidar/src/gestures/detectors/FullTurnDetector.java
+++ b/droidar/src/gestures/detectors/FullTurnDetector.java
@@ -6,6 +6,7 @@ import android.hardware.SensorManager;
 import gestures.PhoneGesture;
 import gestures.PhoneGestureDetector;
 import gestures.SensorData;
+import gestures.StandardPhoneGesture;
 
 /**
  * The FullTurnDetector can be used to determine whether the player has
@@ -51,7 +52,7 @@ public class FullTurnDetector implements PhoneGestureDetector {
 
 	@Override
 	public PhoneGesture getType() {
-		return PhoneGesture.FULL_TURN;
+		return StandardPhoneGesture.FULL_TURN;
 	}
 
 	@Override

--- a/droidar/src/gestures/detectors/LoggingDetector.java
+++ b/droidar/src/gestures/detectors/LoggingDetector.java
@@ -4,6 +4,7 @@ import android.util.Log;
 import gestures.PhoneGesture;
 import gestures.PhoneGestureDetector;
 import gestures.SensorData;
+import gestures.StandardPhoneGesture;
 
 /**
  * A dummy detector that's simply printing out the measured sensor data to the
@@ -34,7 +35,7 @@ public class LoggingDetector implements PhoneGestureDetector {
 
 	@Override
 	public PhoneGesture getType() {
-		return PhoneGesture.NONE;
+		return StandardPhoneGesture.NONE;
 	}
 
 	@Override

--- a/droidar/src/gestures/detectors/LookingDetector.java
+++ b/droidar/src/gestures/detectors/LookingDetector.java
@@ -3,6 +3,7 @@ package gestures.detectors;
 import gestures.PhoneGesture;
 import gestures.PhoneGestureDetector;
 import gestures.SensorData;
+import gestures.StandardPhoneGesture;
 
 /**
  * A detector which detects if the user is holding the phone stable for a
@@ -35,7 +36,7 @@ public class LookingDetector implements PhoneGestureDetector {
 
 	@Override
 	public PhoneGesture getType() {
-		return PhoneGesture.LOOKING;
+		return StandardPhoneGesture.LOOKING;
 	}
 
 	@Override

--- a/droidar/src/gestures/detectors/SlashDetector.java
+++ b/droidar/src/gestures/detectors/SlashDetector.java
@@ -3,6 +3,7 @@ package gestures.detectors;
 import gestures.PhoneGesture;
 import gestures.PhoneGestureDetector;
 import gestures.SensorData;
+import gestures.StandardPhoneGesture;
 
 /**
  * A detector to detect "Slashing" movements by simple peak detection.
@@ -30,7 +31,7 @@ public class SlashDetector implements PhoneGestureDetector {
 
 	@Override
 	public PhoneGesture getType() {
-		return PhoneGesture.SLASH;
+		return StandardPhoneGesture.SLASH;
 	}
 
 	@Override

--- a/droidar/src/gestures/detectors/UppercutDetector.java
+++ b/droidar/src/gestures/detectors/UppercutDetector.java
@@ -3,6 +3,7 @@ package gestures.detectors;
 import gestures.PhoneGesture;
 import gestures.PhoneGestureDetector;
 import gestures.SensorData;
+import gestures.StandardPhoneGesture;
 import util.Vec;
 
 public class UppercutDetector implements PhoneGestureDetector {
@@ -18,7 +19,7 @@ public class UppercutDetector implements PhoneGestureDetector {
 
 	@Override
 	public PhoneGesture getType() {
-		return PhoneGesture.UPPERCUT;
+		return StandardPhoneGesture.UPPERCUT;
 	}
 
 	@Override


### PR DESCRIPTION
Makes use of "extensible enum pattern" so that third party
clients can easily create new gesture types without having
to modify the DroidAR library.

See also: [blogs.oracle.comdarcy/entry/enums_and_mixins](https://blogs.oracle.com/darcy/entry/enums_and_mixins)

Note: this is a breaking change. Since `PhoneGesture`s
are a very new part of the library and extensibility was not
possible before this commit, we suspect that not many
clients have adopted this sensor yet, though.

Signed-off-by: Martin Matysiak kaktus621@gmail.com
